### PR TITLE
Disable `reusePaths`

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -61,7 +61,7 @@ const svgo = new SVGO({
     { removeScriptElement: false },
     { addAttributesToSVGElement: false },
     { removeOffCanvasPaths: true },
-    { reusePaths: true }
+    { reusePaths: false }
   ]
 })
 


### PR DESCRIPTION
`reusePaths` is incompatible with `multipass`: https://github.com/svg/svgo/issues/1200