### PR TITLE
Minor README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ module.exports = {
     contentType
     url
     fileName
-    contentType
     details {
       image {
         width


### PR DESCRIPTION
`contentType` is stated twice in the example query