### PR TITLE
fix ids collision

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -25,8 +25,17 @@ const svgo = new SVGO({
     { inlineStyles: true },
     { minifyStyles: true },
     { convertStyleToAttrs: true },
-    { cleanupIDs: true },
-    { prefixIds: true },
+    {
+      cleanupIDs: {
+        prefix: {
+          toString() {
+            const prefix = `svg${count}_`
+            count++
+            return prefix
+          }
+        }
+      }
+    },
     { removeRasterImages: true },
     { removeUselessDefs: true },
     { cleanupNumericValues: true },


### PR DESCRIPTION
- The first solution I tried is:
```
let count = 0
{
   prefixIds: {
     prefix: () => {-
       const prefix = `svg${count}`;
       count++;
       return prefix;
     }
   }
 }
```
but ids are prefixed twice like so`id="svg97__svg90__a"` and in one case a `linearGradient` that has an id was removed and the svg was broken while this `linearGradient` was referenced by a `rect` so i don't know why it was removed.

- The second solution I tried which is working perfectly:
I removed `prefixIds` plugin completely and used the `prefix` option at `cleanupIDs` as following:
```
let count = 0
{
    cleanupIDs: {
      prefix: {
         toString() {
           const prefix = `svg${count}_`
           count++
           return prefix
         }
      }
   }
}
```
JavaScript objects invokes `toString` when converting from `object` to `string` for concatenation. The `function` can be used to generate unique ids.
The concatenation happens here: https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js#L209
The result was as expected: `id="svg2_a"`