### PR TITLE
Fix ids collisions

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -115,7 +115,9 @@ async function parseSVG({
       source.contentful_id + ': ' + absolutePath
     )
   }
-  const { data: optimizedSVG } = await svgo.optimize(svg)
+  const { data: optimizedSVG } = await svgo.optimize(svg, {
+    path: absolutePath
+  })
 
   // Create mini data URI
   const dataURI = svgToMiniDataURI(optimizedSVG)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">8.0.0"
   },
   "scripts": {
-    "format": "prettier --write '{src/**/*.js,*.{js,json}}'",
+    "format": "prettier --write {src/**/*.js,*.{js,json}}",
     "lint": "eslint index.js"
   },
   "files": [


### PR DESCRIPTION
This is the solution I mentioned [here](https://github.com/axe312ger/gatsby-transformer-inline-svg/pull/8#issuecomment-580870603) which is working as expected, for example, if the svg's file name is `next.svg` the resulted ids are `next_svg__a` and `next_svg__b`.
I removed the single quotes from the format script because it didn't work properly until I did. I'm using windows 10 and I tested that on git bash, cmder, command prompt.