### PR TITLE
Move gatsby to peerdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "prettier": "^1.19.1"
   },
   "peerDependencies": {
-    "gatsby-source-contentful": "^2.1.62"
+    "gatsby-source-contentful": "^2.1.62",
     "gatsby": "^2.19.11 || ^3.0.0-next.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "dependencies": {
     "debug": "^4.1.1",
     "fs-extra": "^8.1.0",
-    "gatsby": "^2.19.11",
     "gatsby-source-filesystem": "^2.1.48",
     "mini-svg-data-uri": "^1.1.3",
     "p-queue": "^6.2.1",
@@ -64,11 +63,13 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
+    "gatsby": "^2.19.11",
     "husky": "^4.2.1",
     "lint-staged": "^10.0.7",
     "prettier": "^1.19.1"
   },
   "peerDependencies": {
     "gatsby-source-contentful": "^2.1.62"
+    "gatsby": "^2.19.11 || ^3.0.0-next.0"
   }
 }


### PR DESCRIPTION
Gatsby should be a peerdependency.

I've made this change through github UI so it might be breaking 😬 